### PR TITLE
Add archive of previous talks with links to slides / code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/README.md
+++ b/README.md
@@ -19,4 +19,4 @@ it's best to follow us on [Twitter (@berlinjs)](http://twitter.com/berlinjs)
 ## How long should my talk be?
 
 This varies depending on the format of your talk, but it shouldn't be longer than
-25 minutes. A lightning talk should of 5 minutes long.
+25 minutes. A lightning talk should be 5 minutes long.

--- a/archive.html
+++ b/archive.html
@@ -38,15 +38,15 @@
   </head>
   <body>
     <header role="banner" class="clearfix">
-      <hgroup class="clearfix">
-      <a href="/" title="BERLIN.JS"><h1 class="logo"></h1></a>
-      <h3 class="ug-info triangle-border left">
-        Berlin.JS is a usergroup focused on JavaScript and related topics. We meet regularly on
-        the 3rd Thursday each month at 7p.m. at
-        <a href="http://co-up.de" title="co.up Coworking">co.up Offices</a>,
-        Adalbertstraße 7-8 in Berlin-Kreuzberg.
-      </h3>
-      </hgroup>
+      <div class="clearfix">
+        <a href="/" title="BERLIN.JS"><h1 class="logo"></h1></a>
+        <h3 class="ug-info triangle-border left">
+          Berlin.JS is a usergroup focused on JavaScript and related topics. We meet regularly on
+          the 3rd Thursday each month at 7p.m. at
+          <a href="http://co-up.de" title="co.up Coworking">co.up Offices</a>,
+          Adalbertstraße 7-8 in Berlin-Kreuzberg.
+        </h3>
+      </div>
     </header>
     <div role="main" class="content clearfix">
 

--- a/archive.html
+++ b/archive.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>BerlinJS &mdash; Berlin's finest JavaScript Usergroup</title>
+    <title>BerlinJS &mdash; Archive of Previous Talks</title>
     <meta name="description" content="Berlin.JS is a usergroup focused on JavaScript and related
      topics. We meet regularly on the 3rd Thursday each month at 7p.m. at co.up Offices,
      Adalbertstraße 7-8 in Berlin-Kreuzberg.">
@@ -49,9 +49,12 @@
       </hgroup>
     </header>
     <div role="main" class="content clearfix">
+
       <article class="clearfix">
         <header class="clearfix center">
-          <h1>Next meetup on October 17<sup>th</sup></h1>
+          <h1>
+            Meetup October 17<sup>th</sup>, 2013
+          </h1>
         </header>
         <section class="clearfix">
         <!-- TALKS -->
@@ -70,41 +73,65 @@
           <div class="three-cols clearfix">
 
             <div class="speaker">
-              <h3>All that JS</h3>
-              <h5><a href="http://twitter.com/franatique">Frank Leue</a></h5>
+              <h3>
+                All that JS
+              </h3>
+              <h5>
+                <a href="http://twitter.com/franatique">Frank Leue</a>
+              </h5>
               <p>
                 We have to admit: We got lazy with proper usage of JS. Frameworks, Boilerplates and such allure
-                  us with promises and let us forget how to properly dose something that imposes stress to the browser.
+                us with promises and let us forget how to properly dose something that imposes stress to the browser.
               </p>
               <p>
-                  This talk will show you techniques to slim your JS and ramp up your page speed.</a>.
+                  This talk will show you techniques to slim your JS and ramp up your page speed.
+              </p>
+              <p>
+                <a href="https://speakerdeck.com/franatique/all-that-js" title="Slides for All that JS">Slides</a>
               </p>
             </div>
 
             <div class="speaker">
-              <h3>JavaScript Code Reuse Patterns - Function Based Object/Type Composition</h3>
-              <h5><a href="https://twitter.com/petsel">Peter Seliger</a></h5>
+              <h3>
+                JavaScript Code Reuse Patterns - Function Based Object/Type Composition
+              </h3>
+              <h5>
+                <a href="https://twitter.com/petsel">Peter Seliger</a>
+              </h5>
               <p>
                 JavaScript - a delegation language; Roles, functional Trait/Mixin modules in JS; examples.
               </p>
               <p>
                 <em>( ... functions as Advices if there is interest yet and/or still time left.)</em>
               </p>
+              <p>
+                <a href="http://petsel.github.io/javascript-code-reuse-patterns/" title="Slides">Slides</a> /
+                <a href="https://github.com/petsel/javascript-code-reuse-patterns" title="Code">Code</a>
+              </p>
             </div>
 
             <div class="speaker">
-              <h3>API.js</h3>
-              <h5><a href="http://twitter.com/patrickheneise">Patrick Heneise</a></h5>
+              <h3>
+                API.js
+              </h3>
+              <h5>
+                <a href="http://twitter.com/patrickheneise">Patrick Heneise</a>
+              </h5>
               <p>
                 In a world of mobile apps, single-page applications and flying web servers, JavaScript, Objective-C,
                 Java and whats-so-not consumers, solid APIs are getting more and more important. This talk is about how
                 to create, test and document an API in Node.js with Express, Mocha, Dox and iodocs.
+              </p>
+              <p>
+                <a href="https://speakerdeck.com/patrickheneise/api-dot-js" title="Slides">Slides</a> /
+                <a href="https://github.com/PatrickHeneise/TheJunkAPI" title="Code">Code</a>
               </p>
             </div>
 
           </div>
         </section>
       </article>
+
     </div>
     <footer class="clearfix three-cols">
       <div>
@@ -120,7 +147,7 @@
             Watch the code on <a href="https://github.com/berlinjs/berlinjs.org" title="Berlin.JS code on Github">Github</a>
           </li>
           <li>
-            Browse the archive of <a href="./archive.html" title="Slides from previous meetups">Slides</a>
+            Browse the archive <a href="./archive.html" title="Slides from previous meetups">Slides</a>
           </li>
         </ul>
       </div>

--- a/index.html
+++ b/index.html
@@ -38,15 +38,15 @@
   </head>
   <body>
     <header role="banner" class="clearfix">
-      <hgroup class="clearfix">
-      <a href="/" title="BERLIN.JS"><h1 class="logo"></h1></a>
-      <h3 class="ug-info triangle-border left">
-        Berlin.JS is a usergroup focused on JavaScript and related topics. We meet regularly on
-        the 3rd Thursday each month at 7p.m. at
-        <a href="http://co-up.de" title="co.up Coworking">co.up Offices</a>,
-        Adalbertstraße 7-8 in Berlin-Kreuzberg.
-      </h3>
-      </hgroup>
+      <div class="clearfix">
+        <a href="/" title="BERLIN.JS"><h1 class="logo"></h1></a>
+        <h3 class="ug-info triangle-border left">
+          Berlin.JS is a usergroup focused on JavaScript and related topics. We meet regularly on
+          the 3rd Thursday each month at 7p.m. at
+          <a href="http://co-up.de" title="co.up Coworking">co.up Offices</a>,
+          Adalbertstraße 7-8 in Berlin-Kreuzberg.
+        </h3>
+      </div>
     </header>
     <div role="main" class="content clearfix">
       <article class="clearfix">


### PR DESCRIPTION
I asked for it, here's the PR that adds an archive of slides from previous talks. 

Adds some code duplication (I haven't tried Jekyll yet).

Feel free to cherry-pick.
