### PR TITLE
Remove stray closing tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
                   us with promises and let us forget how to properly dose something that imposes stress to the browser.
               </p>
               <p>
-                  This talk will show you techniques to slim your JS and ramp up your page speed.</a>.
+                  This talk will show you techniques to slim your JS and ramp up your page speed.
               </p>
             </div>
 


### PR DESCRIPTION
Because we :heart: valid HTML.

On a separate note, some more validation errors are reported.
