### PR TITLE
Throw in some Jekyll for rendering BerlinJS site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .idea
+_site

--- a/_config.yml
+++ b/_config.yml
@@ -2,3 +2,4 @@ source: .
 target: _site
 timezone: Europe/Berlin
 encoding: UTF-8
+markdown: redcarpet

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,3 @@
-source: .
-target: _site
-timezone: Europe/Berlin
+gtimezone: Europe/Berlin
 encoding: UTF-8
 markdown: redcarpet

--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,3 @@
-gtimezone: Europe/Berlin
+timezone: Europe/Berlin
 encoding: UTF-8
 markdown: redcarpet

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,4 @@
+source: .
+target: _site
+timezone: Europe/Berlin
+encoding: UTF-8

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -1,0 +1,77 @@
+# THIS IS HOW A TALK ABSTRACT LOOKS LIKE
+# - |
+#   ### Your topic
+#   ##### [Your Name](http://twitter.com/your_twitter_handle)
+#
+#   Description
+#
+#   Further description
+
+- time: 2013-11-21 19:00:00 +0100
+  talks:
+    - |
+      ### JavaScript as the future of Progressive Enhancement
+      ##### [Tiago Rodrigues](http://twitter.com/trodrigues)
+
+      In recent times the web development community has been divided over the way JavaScript is used on modern web
+      development and how Progressive Enhancement has been abandoned by so many developers. But what if JavaScript is
+      the future of Progressive Enhancement?
+
+      This talk will go through various solutions for doing modern web development while keeping JavaScript as a first class citizen and taking advantage of all the good things Progressive Enhancement has to offer.
+
+    - |
+      ### JavaScript Method Modification - Aspect Oriented Function Composition
+      ##### [Peter Seliger](https://twitter.com/petsel)
+
+      Within the last years only on GitHub the amount of JavaScript libraries that claim to support Aspect Oriented
+      Programming (AOP) has risen significantly. But there is a difference between wrapping functions in a basic way and
+      the complexity that has to be handled by aspect oriented approaches.
+
+      The goal of this talk is to distinguish both. Live Coding examples might point to what developers are really
+      looking for.
+
+    - |
+      ### Solving the callback hell through generators and promises
+      ##### Andreas Lubbe
+
+      JavaScript has the tendency to produce callback code that is constantly headed for the right edge of the screen
+      and makes error checking &amp; handling anything but fun. The async library doesn't help much with errors,
+      promises are slow and fibers unreliable. So what to do?
+
+      ES6 has introduced generators and newer libraries such as bluebird offer the flexibility of promises with the
+      speed of async. This talk will introduce these concepts and show live demos and benchmarks.
+
+- time: 2013-10-17 19:00:00 +0100
+  talks:
+    - |
+      ### All that JS
+      ##### [Frank Leue](http://twitter.com/franatique)
+
+      We have to admit: We got lazy with proper usage of JS. Frameworks, Boilerplates and such allure us with promises and
+      let us forget how to properly dose something that imposes stress to the browser.
+
+      This talk will show you techniques to slim your JS and ramp up your page speed.
+
+      [Slides](https://speakerdeck.com/franatique/all-that-js)
+
+    - |
+      ### JavaScript Code Reuse Patterns - Function Based Object/Type Composition
+      ##### [Peter Seliger](https://twitter.com/petsel)
+
+      JavaScript - a delegation language; Roles, functional Trait/Mixin modules in JS; examples.
+
+      *( ... functions as Advices if there is interest yet and/or still time left.)*
+
+      [Slides](http://petsel.github.io/javascript-code-reuse-patterns/) /
+      [Code](https://github.com/petsel/javascript-code-reuse-patterns)
+
+    - |
+      ### API.js
+      ##### [Patrick Heneise](http://twitter.com/patrickheneise)
+
+      In a world of mobile apps, single-page applications and flying web servers, JavaScript, Objective-C, Java and
+      whats-so-not consumers, solid APIs are getting more and more important. This talk is about how to create, test and
+      document an API in Node.js with Express, Mocha, Dox and iodocs.
+
+      [Slides](https://speakerdeck.com/patrickheneise/api-dot-js) /
+      [Code](https://github.com/PatrickHeneise/TheJunkAPI)

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -9,6 +9,15 @@
 
 - time: 2014-01-16 19:00:00 +0100
   talks:
+    - |
+      ### Player.js: Control Media Iframes
+      ##### [Sean Creeley](http://twitter.com/screeley)
+
+      [Player.js](https://github.com/embedly/player.js) is a library for programmatically running actions like play,
+      pause, mute, and seek for a wide variety of media providers.
+
+      This talk will focus on building the media iframe, using postMessage and the Player.js library itself. We will
+      also discuss some of the immediate possibilities like event listening for media analytics and playlist apps.
 
 - time: 2013-11-21 19:00:00 +0100
   talks:

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -7,6 +7,27 @@
 #
 #   Further description
 
+- time: 2014-02-20 19:00:00 +0100
+  talks:
+    - |
+      ### Player.js: Control Media Iframes
+      ##### [Sean Creeley](http://twitter.com/screeley)
+
+      [Player.js](https://github.com/embedly/player.js) is a library for programmatically running actions like play,
+      pause, mute, and seek for a wide variety of media providers.
+
+      This talk will focus on building the media iframe, using postMessage and the Player.js library itself. We will
+      also discuss some of the immediate possibilities like event listening for media analytics and playlist apps.
+
+      ### Basics of Canvas Game Development
+      ##### [Oliver Zeigermann](http://twitter.com/DJCordhose)
+
+      In this live coding sessions I will introduce you to the basics of JavaScript and Canvas game development.
+      We will do something like this little game ([http://zeigermann.eu/balls/](http://zeigermann.eu/balls/)) more or
+      less from scratch.
+
+      Topics will include canvas basics, game loop, player control, physics, and game logic.
+
 - time: 2014-01-16 19:00:00 +0100
   talks:
     - |

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -19,6 +19,8 @@
 
       This talk will go through various solutions for doing modern web development while keeping JavaScript as a first class citizen and taking advantage of all the good things Progressive Enhancement has to offer.
 
+      [Slides](https://github.com/trodrigues/js-pe-slides)
+
     - |
       ### JavaScript Method Modification - Aspect Oriented Function Composition
       ##### [Peter Seliger](https://twitter.com/petsel)

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -7,6 +7,9 @@
 #
 #   Further description
 
+- time: 2014-01-16 19:00:00 +0100
+  talks:
+
 - time: 2013-11-21 19:00:00 +0100
   talks:
     - |

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -32,6 +32,9 @@
       The goal of this talk is to distinguish both. Live Coding examples might point to what developers are really
       looking for.
 
+      [Slides](http://petsel.github.io/javascript-method-modification/talk/slides/#/cover) /
+      [Code](http://petsel.github.io/javascript-method-modification/)
+
     - |
       ### Solving the callback hell through generators and promises
       ##### Andreas Lubbe

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -19,6 +19,15 @@
       This talk will focus on building the media iframe, using postMessage and the Player.js library itself. We will
       also discuss some of the immediate possibilities like event listening for media analytics and playlist apps.
 
+    - |
+      ### Sqwiggle: How we JavaScript
+      ##### [Luke Roberts](https://twitter.com/lukeroberts1990)
+
+      Sqwiggle is an online office and collaboration space for remote teams. We are on the bleeding edge with WebRTC and
+      use a LOT of JS.
+
+      This talk is a brief overview of the Sqwiggle stack, WebRTC and our approach to using Javascript.
+
 - time: 2013-11-21 19:00:00 +0100
   talks:
     - |

--- a/_data/meetups.yml
+++ b/_data/meetups.yml
@@ -10,15 +10,6 @@
 - time: 2014-02-20 19:00:00 +0100
   talks:
     - |
-      ### Player.js: Control Media Iframes
-      ##### [Sean Creeley](http://twitter.com/screeley)
-
-      [Player.js](https://github.com/embedly/player.js) is a library for programmatically running actions like play,
-      pause, mute, and seek for a wide variety of media providers.
-
-      This talk will focus on building the media iframe, using postMessage and the Player.js library itself. We will
-      also discuss some of the immediate possibilities like event listening for media analytics and playlist apps.
-
       ### Basics of Canvas Game Development
       ##### [Oliver Zeigermann](http://twitter.com/DJCordhose)
 

--- a/_includes/empty.html
+++ b/_includes/empty.html
@@ -1,0 +1,10 @@
+<div class="speaker">
+  <div class="speaker empty">
+    <h3>Free slot</h3>
+    <h5>This slot could be yours!<br />Submit your talk now.</h5>
+    <p>You did some crazy stuff with JavaScript? You want to show it to the community?</p>
+    <p>Drop us a line on your topic on <a href="http://twitter.com/berlinjs" title="BerlinJS on Twitter">Twitter</a> or
+      to our <a href="http://groups.google.com/group/js-berlin" title="BerlinJS Mailinglist">Mailinglist</a>.
+    </p>
+  </div>
+</div>

--- a/_includes/empty.html
+++ b/_includes/empty.html
@@ -1,10 +1,8 @@
-<div class="speaker">
-  <div class="speaker empty">
-    <h3>Free slot</h3>
-    <h5>This slot could be yours!<br />Submit your talk now.</h5>
-    <p>You did some crazy stuff with JavaScript? You want to show it to the community?</p>
-    <p>Drop us a line on your topic on <a href="http://twitter.com/berlinjs" title="BerlinJS on Twitter">Twitter</a> or
-      to our <a href="http://groups.google.com/group/js-berlin" title="BerlinJS Mailinglist">Mailinglist</a>.
-    </p>
-  </div>
+<div class="speaker empty">
+  <h3>Free slot</h3>
+  <h5>This slot could be yours!<br />Submit your talk now.</h5>
+  <p>You did some crazy stuff with JavaScript? You want to show it to the community?</p>
+  <p>Drop us a line on your topic on <a href="http://twitter.com/berlinjs" title="BerlinJS on Twitter">Twitter</a> or
+    to our <a href="http://groups.google.com/group/js-berlin" title="BerlinJS Mailinglist">Mailinglist</a>.
+  </p>
 </div>

--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -13,10 +13,9 @@
       </div>
       {% endfor %}
 
-      {% assign totalSlots = "1,2,3" | split: "," %}
-      {% assign takenSlots = include.meetup.talks | size %}
+      {% assign taken = include.meetup.talks | size %}
 
-      {% for slot in totalSlots | limit: 3 offset: takenSlots %}
+      {% for i in (taken..2) %}
         {% include empty.html %}
       {% endfor %}
 

--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -1,0 +1,18 @@
+<article class="clearfix">
+  <header class="clearfix center">
+    <h1>
+      {{ include.prefix }} {{ include.meetup.time | date: "%B %d, %Y" }}
+    </h1>
+  </header>
+  <section class="clearfix">
+    <div class="three-cols clearfix">
+
+      {% for talk in include.meetup.talks %}
+      <div class="speaker">
+        {{ talk | markdownify }}
+      </div>
+      {% endfor %}
+
+    </div>
+  </section>
+</article>

--- a/_includes/meetup.html
+++ b/_includes/meetup.html
@@ -7,10 +7,17 @@
   <section class="clearfix">
     <div class="three-cols clearfix">
 
-      {% for talk in include.meetup.talks %}
+      {% for talk in include.meetup.talks | limit: 3 %}
       <div class="speaker">
         {{ talk | markdownify }}
       </div>
+      {% endfor %}
+
+      {% assign totalSlots = "1,2,3" | split: "," %}
+      {% assign takenSlots = include.meetup.talks | size %}
+
+      {% for slot in totalSlots | limit: 3 offset: takenSlots %}
+        {% include empty.html %}
       {% endfor %}
 
     </div>

--- a/_layouts/berlinjs.html
+++ b/_layouts/berlinjs.html
@@ -51,39 +51,55 @@
     <div role="main" class="content clearfix">
       {{ content }}
     </div>
-    <footer class="clearfix three-cols">
-      <div>
-        <h5>Get in touch</h5>
-        <ul>
-          <li>
-            Follow Berlin.JS on <a href="http://twitter.com/berlinjs" title="Follow us on Twitter">Twitter</a>
-          </li>
-          <li>
-            Join our <a href="http://groups.google.com/group/js-berlin" title="Join our Mailinglist">Mailinglist</a>
-          </li>
-          <li>
-            Watch the code on <a href="https://github.com/berlinjs/berlinjs.org" title="Berlin.JS code on Github">Github</a>
-          </li>
-          <li>
-            Browse the archive of <a href="./archive.html" title="Slides from previous meetups">Slides</a>
-          </li>
-        </ul>
+    <footer>
+      <div class="clearfix three-cols">
+        <div>
+          <h5>Get in touch</h5>
+          <ul>
+            <li>
+              Follow Berlin.JS on <a href="http://twitter.com/berlinjs" title="Follow us on Twitter">Twitter</a>
+            </li>
+            <li>
+              Join our <a href="http://groups.google.com/group/js-berlin" title="Join our Mailinglist">Mailinglist</a>
+            </li>
+            <li>
+              Watch the code on <a href="https://github.com/berlinjs/berlinjs.org" title="Berlin.JS code on Github">Github</a>
+            </li>
+            <li>
+              Browse the archive of <a href="./archive.html" title="Slides from previous meetups">Slides</a>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h5>The team</h5>
+          <p>
+            Berlin.JS is organized by <a href="http://www.twitter.com/rmehner" title="Follow Robin on
+            Twitter">Robin Mehner</a>, <a href="http://www.twitter.com/janl" title="Follow Jan on
+            Twitter">Jan Lehnardt</a> &amp; <a href="http://www.twitter.com/theophani" title="Follow Tiffany on
+            Twitter">Tiffany Conroy</a>. Design by <a href="http://www.twitter.com/m_besser"
+                                                      title="Follow Matti on Twitter">Matti Besser</a>.
+          </p>
+        </div>
+        <div>
+          <h5>Supporters</h5>
+          <p>
+            Our Meetups are hosted by <a href="http://www.co-up.de" title="co.up Coworking">co.up</a>.
+          </p>
+        </div>
       </div>
-      <div>
-        <h5>The team</h5>
-        <p>
-          Berlin.JS is organized by <a href="http://www.twitter.com/rmehner" title="Follow Robin on
-          Twitter">Robin Mehner</a>, <a href="http://www.twitter.com/janl" title="Follow Jan on
-          Twitter">Jan Lehnardt</a> &amp; <a href="http://www.twitter.com/theophani" title="Follow Tiffany on
-          Twitter">Tiffany Conroy</a>. Design by <a href="http://www.twitter.com/m_besser"
-          title="Follow Matti on Twitter">Matti Besser</a>.
-        </p>
-      </div>
-      <div>
-        <h5>Supporters</h5>
-        <p>
-          Our Meetups are hosted by <a href="http://www.co-up.de" title="co.up Coworking">co.up</a>.
-        </p>
+      <div class="clearfix one-col">
+        <div>
+          <h5>Code of Conduct</h5>
+          <p>
+            Long story short: <strong>Be awesome to each other.</strong>
+          </p>
+          <p>
+            Our goal is to have an awesome and inclusive community meetup where people meet,
+            hang out together, chat, listen to talks, exchange ideas and make new friends.
+            Any harmful or discriminating behaviour will not be tolerated and results
+            in the offending person being expelled from the meetup.
+          </p>
+        </div>
       </div>
     </footer>
     <script>

--- a/_layouts/berlinjs.html
+++ b/_layouts/berlinjs.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>BerlinJS &mdash; {{ page.title }}</title>
+    <meta name="description" content="Berlin.JS is a usergroup focused on JavaScript and related
+     topics. We meet regularly on the 3rd Thursday each month at 7p.m. at co.up Offices,
+     Adalbertstraße 7-8 in Berlin-Kreuzberg.">
+    <meta name="keywords" content="JavaScript, Usergroup, Berlin, Programming, JS">
+    <meta name="author" content="Berlin.JS">
+    <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1">
+    <!-- disable cache completely for now -->
+    <meta http-equiv="cache-control" content="max-age=0" />
+    <meta http-equiv="cache-control" content="no-cache" />
+    <meta http-equiv="expires" content="0" />
+    <meta http-equiv="expires" content="Thu, 01 Jan 1970 13:37:00 GMT" />
+    <meta http-equiv="pragma" content="no-cache" />
+    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="stylesheet" media="screen" href="css/style.css?v=1">
+    <link rel="stylesheet" media="print" href="css/print.css?v=1">
+
+    <link rel="stylesheet" media="only screen and (min-width: 480px)" href="css/480.css?v=1">
+    <link rel="stylesheet" media="only screen and (min-width: 768px)" href="css/768.css?v=1">
+    <link rel="stylesheet" media="only screen and (min-width: 992px)" href="css/992.css?v=1">
+    <link rel="stylesheet" media="only screen and (min-width: 1382px)" href="css/1382.css?v=1">
+
+    <link rel="stylesheet" media="only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2)" href="css/2x.css?v=1">
+
+    <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
+
+    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png"/>
+    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png"/>
+    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png"/>
+    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png"/>
+
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  </head>
+  <body>
+    <header role="banner" class="clearfix">
+      <div class="clearfix">
+        <a href="/" title="BERLIN.JS"><h1 class="logo"></h1></a>
+        <h3 class="ug-info triangle-border left">
+          Berlin.JS is a usergroup focused on JavaScript and related topics. We meet regularly on
+          the 3rd Thursday each month at 7p.m. at
+          <a href="http://co-up.de" title="co.up Coworking">co.up Offices</a>,
+          Adalbertstraße 7-8 in Berlin-Kreuzberg.
+        </h3>
+      </div>
+    </header>
+    <div role="main" class="content clearfix">
+      {{ content }}
+    </div>
+    <footer class="clearfix three-cols">
+      <div>
+        <h5>Get in touch</h5>
+        <ul>
+          <li>
+            Follow Berlin.JS on <a href="http://twitter.com/berlinjs" title="Follow us on Twitter">Twitter</a>
+          </li>
+          <li>
+            Join our <a href="http://groups.google.com/group/js-berlin" title="Join our Mailinglist">Mailinglist</a>
+          </li>
+          <li>
+            Watch the code on <a href="https://github.com/berlinjs/berlinjs.org" title="Berlin.JS code on Github">Github</a>
+          </li>
+          <li>
+            Browse the archive of <a href="./archive.html" title="Slides from previous meetups">Slides</a>
+          </li>
+        </ul>
+      </div>
+      <div>
+        <h5>The team</h5>
+        <p>
+          Berlin.JS is organized by <a href="http://www.twitter.com/rmehner" title="Follow Robin on
+          Twitter">Robin Mehner</a>, <a href="http://www.twitter.com/janl" title="Follow Jan on
+          Twitter">Jan Lehnardt</a> &amp; <a href="http://www.twitter.com/theophani" title="Follow Tiffany on
+          Twitter">Tiffany Conroy</a>. Design by <a href="http://www.twitter.com/m_besser"
+          title="Follow Matti on Twitter">Matti Besser</a>.
+        </p>
+      </div>
+      <div>
+        <h5>Supporters</h5>
+        <p>
+          Our Meetups are hosted by <a href="http://www.co-up.de" title="co.up Coworking">co.up</a>.
+        </p>
+      </div>
+    </footer>
+    <script>
+      var _gaq = [['_setAccount','UA-25036346-1'],['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.async = g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
+    </script>
+  </body>
+</html>

--- a/archive.html
+++ b/archive.html
@@ -1,168 +1,72 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>BerlinJS &mdash; Archive of Previous Talks</title>
-    <meta name="description" content="Berlin.JS is a usergroup focused on JavaScript and related
-     topics. We meet regularly on the 3rd Thursday each month at 7p.m. at co.up Offices,
-     Adalbertstraße 7-8 in Berlin-Kreuzberg.">
-    <meta name="keywords" content="JavaScript, Usergroup, Berlin, Programming, JS">
-    <meta name="author" content="Berlin.JS">
-    <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1">
-    <!-- disable cache completely for now -->
-    <meta http-equiv="cache-control" content="max-age=0" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="expires" content="0" />
-    <meta http-equiv="expires" content="Thu, 01 Jan 1970 13:37:00 GMT" />
-    <meta http-equiv="pragma" content="no-cache" />
-    <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" media="screen" href="css/style.css?v=1">
-    <link rel="stylesheet" media="print" href="css/print.css?v=1">
+---
+layout: berlinjs
+title: Archive of Previous Talks
+---
+<article class="clearfix">
+  <header class="clearfix center">
+    <h1>
+      Meetup October 17<sup>th</sup>, 2013
+    </h1>
+  </header>
+  <section class="clearfix">
+    <div class="three-cols clearfix">
 
-    <link rel="stylesheet" media="only screen and (min-width: 480px)" href="css/480.css?v=1">
-    <link rel="stylesheet" media="only screen and (min-width: 768px)" href="css/768.css?v=1">
-    <link rel="stylesheet" media="only screen and (min-width: 992px)" href="css/992.css?v=1">
-    <link rel="stylesheet" media="only screen and (min-width: 1382px)" href="css/1382.css?v=1">
-
-    <link rel="stylesheet" media="only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2)" href="css/2x.css?v=1">
-
-    <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
-
-    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png"/>
-    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png"/>
-    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png"/>
-    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png"/>
-
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  </head>
-  <body>
-    <header role="banner" class="clearfix">
-      <div class="clearfix">
-        <a href="/" title="BERLIN.JS"><h1 class="logo"></h1></a>
-        <h3 class="ug-info triangle-border left">
-          Berlin.JS is a usergroup focused on JavaScript and related topics. We meet regularly on
-          the 3rd Thursday each month at 7p.m. at
-          <a href="http://co-up.de" title="co.up Coworking">co.up Offices</a>,
-          Adalbertstraße 7-8 in Berlin-Kreuzberg.
+      <div class="speaker">
+        <h3>
+          All that JS
         </h3>
+        <h5>
+          <a href="http://twitter.com/franatique">Frank Leue</a>
+        </h5>
+        <p>
+          We have to admit: We got lazy with proper usage of JS. Frameworks, Boilerplates and such allure
+          us with promises and let us forget how to properly dose something that imposes stress to the browser.
+        </p>
+        <p>
+            This talk will show you techniques to slim your JS and ramp up your page speed.
+        </p>
+        <p>
+          <a href="https://speakerdeck.com/franatique/all-that-js" title="Slides for All that JS">Slides</a>
+        </p>
       </div>
-    </header>
-    <div role="main" class="content clearfix">
 
-      <article class="clearfix">
-        <header class="clearfix center">
-          <h1>
-            Meetup October 17<sup>th</sup>, 2013
-          </h1>
-        </header>
-        <section class="clearfix">
-          <div class="three-cols clearfix">
+      <div class="speaker">
+        <h3>
+          JavaScript Code Reuse Patterns - Function Based Object/Type Composition
+        </h3>
+        <h5>
+          <a href="https://twitter.com/petsel">Peter Seliger</a>
+        </h5>
+        <p>
+          JavaScript - a delegation language; Roles, functional Trait/Mixin modules in JS; examples.
+        </p>
+        <p>
+          <em>( ... functions as Advices if there is interest yet and/or still time left.)</em>
+        </p>
+        <p>
+          <a href="http://petsel.github.io/javascript-code-reuse-patterns/" title="Slides">Slides</a> /
+          <a href="https://github.com/petsel/javascript-code-reuse-patterns" title="Code">Code</a>
+        </p>
+      </div>
 
-            <div class="speaker">
-              <h3>
-                All that JS
-              </h3>
-              <h5>
-                <a href="http://twitter.com/franatique">Frank Leue</a>
-              </h5>
-              <p>
-                We have to admit: We got lazy with proper usage of JS. Frameworks, Boilerplates and such allure
-                us with promises and let us forget how to properly dose something that imposes stress to the browser.
-              </p>
-              <p>
-                  This talk will show you techniques to slim your JS and ramp up your page speed.
-              </p>
-              <p>
-                <a href="https://speakerdeck.com/franatique/all-that-js" title="Slides for All that JS">Slides</a>
-              </p>
-            </div>
-
-            <div class="speaker">
-              <h3>
-                JavaScript Code Reuse Patterns - Function Based Object/Type Composition
-              </h3>
-              <h5>
-                <a href="https://twitter.com/petsel">Peter Seliger</a>
-              </h5>
-              <p>
-                JavaScript - a delegation language; Roles, functional Trait/Mixin modules in JS; examples.
-              </p>
-              <p>
-                <em>( ... functions as Advices if there is interest yet and/or still time left.)</em>
-              </p>
-              <p>
-                <a href="http://petsel.github.io/javascript-code-reuse-patterns/" title="Slides">Slides</a> /
-                <a href="https://github.com/petsel/javascript-code-reuse-patterns" title="Code">Code</a>
-              </p>
-            </div>
-
-            <div class="speaker">
-              <h3>
-                API.js
-              </h3>
-              <h5>
-                <a href="http://twitter.com/patrickheneise">Patrick Heneise</a>
-              </h5>
-              <p>
-                In a world of mobile apps, single-page applications and flying web servers, JavaScript, Objective-C,
-                Java and whats-so-not consumers, solid APIs are getting more and more important. This talk is about how
-                to create, test and document an API in Node.js with Express, Mocha, Dox and iodocs.
-              </p>
-              <p>
-                <a href="https://speakerdeck.com/patrickheneise/api-dot-js" title="Slides">Slides</a> /
-                <a href="https://github.com/PatrickHeneise/TheJunkAPI" title="Code">Code</a>
-              </p>
-            </div>
-
-          </div>
-        </section>
-      </article>
+      <div class="speaker">
+        <h3>
+          API.js
+        </h3>
+        <h5>
+          <a href="http://twitter.com/patrickheneise">Patrick Heneise</a>
+        </h5>
+        <p>
+          In a world of mobile apps, single-page applications and flying web servers, JavaScript, Objective-C,
+          Java and whats-so-not consumers, solid APIs are getting more and more important. This talk is about how
+          to create, test and document an API in Node.js with Express, Mocha, Dox and iodocs.
+        </p>
+        <p>
+          <a href="https://speakerdeck.com/patrickheneise/api-dot-js" title="Slides">Slides</a> /
+          <a href="https://github.com/PatrickHeneise/TheJunkAPI" title="Code">Code</a>
+        </p>
+      </div>
 
     </div>
-    <footer class="clearfix three-cols">
-      <div>
-        <h5>Get in touch</h5>
-        <ul>
-          <li>
-            Follow Berlin.JS on <a href="http://twitter.com/berlinjs" title="Follow us on Twitter">Twitter</a>
-          </li>
-          <li>
-            Join our <a href="http://groups.google.com/group/js-berlin" title="Join our Mailinglist">Mailinglist</a>
-          </li>
-          <li>
-            Watch the code on <a href="https://github.com/berlinjs/berlinjs.org" title="Berlin.JS code on Github">Github</a>
-          </li>
-          <li>
-            Browse the archive of <a href="./archive.html" title="Slides from previous meetups">Slides</a>
-          </li>
-        </ul>
-      </div>
-      <div>
-        <h5>The team</h5>
-        <p>
-          Berlin.JS is organized by <a href="http://www.twitter.com/rmehner" title="Follow Robin on
-          Twitter">Robin Mehner</a>, <a href="http://www.twitter.com/janl" title="Follow Jan on
-          Twitter">Jan Lehnardt</a> &amp; <a href="http://www.twitter.com/theophani" title="Follow Tiffany on
-          Twitter">Tiffany Conroy</a>. Design by <a href="http://www.twitter.com/m_besser"
-          title="Follow Matti on Twitter">Matti Besser</a>.
-        </p>
-      </div>
-      <div>
-        <h5>Supporters</h5>
-        <p>
-          Our Meetups are hosted by <a href="http://www.co-up.de" title="co.up Coworking">co.up</a>.
-        </p>
-      </div>
-    </footer>
-    <script>
-      var _gaq = [['_setAccount','UA-25036346-1'],['_trackPageview']];
-      (function(d, t) {
-        var g = d.createElement(t),
-            s = d.getElementsByTagName(t)[0];
-        g.async = g.src = '//www.google-analytics.com/ga.js';
-        s.parentNode.insertBefore(g, s);
-      }(document, 'script'));
-    </script>
-  </body>
-</html>
+  </section>
+</article>

--- a/archive.html
+++ b/archive.html
@@ -2,71 +2,8 @@
 layout: berlinjs
 title: Archive of Previous Talks
 ---
-<article class="clearfix">
-  <header class="clearfix center">
-    <h1>
-      Meetup October 17<sup>th</sup>, 2013
-    </h1>
-  </header>
-  <section class="clearfix">
-    <div class="three-cols clearfix">
-
-      <div class="speaker">
-        <h3>
-          All that JS
-        </h3>
-        <h5>
-          <a href="http://twitter.com/franatique">Frank Leue</a>
-        </h5>
-        <p>
-          We have to admit: We got lazy with proper usage of JS. Frameworks, Boilerplates and such allure
-          us with promises and let us forget how to properly dose something that imposes stress to the browser.
-        </p>
-        <p>
-            This talk will show you techniques to slim your JS and ramp up your page speed.
-        </p>
-        <p>
-          <a href="https://speakerdeck.com/franatique/all-that-js" title="Slides for All that JS">Slides</a>
-        </p>
-      </div>
-
-      <div class="speaker">
-        <h3>
-          JavaScript Code Reuse Patterns - Function Based Object/Type Composition
-        </h3>
-        <h5>
-          <a href="https://twitter.com/petsel">Peter Seliger</a>
-        </h5>
-        <p>
-          JavaScript - a delegation language; Roles, functional Trait/Mixin modules in JS; examples.
-        </p>
-        <p>
-          <em>( ... functions as Advices if there is interest yet and/or still time left.)</em>
-        </p>
-        <p>
-          <a href="http://petsel.github.io/javascript-code-reuse-patterns/" title="Slides">Slides</a> /
-          <a href="https://github.com/petsel/javascript-code-reuse-patterns" title="Code">Code</a>
-        </p>
-      </div>
-
-      <div class="speaker">
-        <h3>
-          API.js
-        </h3>
-        <h5>
-          <a href="http://twitter.com/patrickheneise">Patrick Heneise</a>
-        </h5>
-        <p>
-          In a world of mobile apps, single-page applications and flying web servers, JavaScript, Objective-C,
-          Java and whats-so-not consumers, solid APIs are getting more and more important. This talk is about how
-          to create, test and document an API in Node.js with Express, Mocha, Dox and iodocs.
-        </p>
-        <p>
-          <a href="https://speakerdeck.com/patrickheneise/api-dot-js" title="Slides">Slides</a> /
-          <a href="https://github.com/PatrickHeneise/TheJunkAPI" title="Code">Code</a>
-        </p>
-      </div>
-
-    </div>
-  </section>
-</article>
+{% for meetup in site.data.meetups %}
+  {% if meetup.time < site.time %}
+    {% include meetup.html meetup=meetup prefix="Meetup on" %}
+  {% endif %}
+{% endfor %}

--- a/archive.html
+++ b/archive.html
@@ -2,7 +2,8 @@
 layout: berlinjs
 title: Archive of Previous Talks
 ---
-{% for meetup in site.data.meetups %}
+{% assign meetups = site.data.meetups | sort: "time" %}
+{% for meetup in meetups reversed %}
   {% if meetup.time < site.time %}
     {% include meetup.html meetup=meetup prefix="Meetup on" %}
   {% endif %}

--- a/css/480.css
+++ b/css/480.css
@@ -199,7 +199,11 @@ body {
 
 /* 11.MAIN */
 
-.one-col > div,
+.one-col > div {
+  width: 96%;
+  margin: 10px 0 0 3%;
+}
+
 .three-cols > div {
   width: 96%;
   margin: 10px 0 0 2%;

--- a/css/768.css
+++ b/css/768.css
@@ -221,7 +221,7 @@ nav li a.active {
 
 .one-col > div {
   width: 96%;
-  margin: 0 auto;
+  margin: 10px 0 0 3%;
 }
 
 .two-cols > div {

--- a/css/style.css
+++ b/css/style.css
@@ -602,7 +602,7 @@ iframe {
 .two-cols,
 .three-cols,
 .four-cols {
-  margin: 10px auto;
+  margin: 10px 0 0 3%;
 }
 
 .three-cols > div {

--- a/index.html
+++ b/index.html
@@ -2,8 +2,6 @@
 layout: berlinjs
 title: Berlin's finest JavaScript Usergroup
 ---
-{% for meetup in site.data.meetups %}
-  {% if meetup.time > site.time %}
-    {% include meetup.html meetup=meetup prefix="Next meetup on" %}
-  {% endif %}
+{% for meetup in site.data.meetups | limit: 1%}
+  {% include meetup.html meetup=meetup prefix="Next meetup on" %}
 {% endfor %}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,8 @@
 layout: berlinjs
 title: Berlin's finest JavaScript Usergroup
 ---
-{% for meetup in site.data.meetups | limit: 1%}
+{% assign meetups = site.data.meetups | sort: "time" %}
+{% assign last = meetups | size | minus: 1 %}
+{% for meetup in meetups reversed | offset: last %}
   {% include meetup.html meetup=meetup prefix="Next meetup on" %}
 {% endfor %}

--- a/index.html
+++ b/index.html
@@ -2,62 +2,8 @@
 layout: berlinjs
 title: Berlin's finest JavaScript Usergroup
 ---
-<article class="clearfix">
-  <header class="clearfix center">
-    <h1>Next meetup on November 21<sup>st</sup></h1>
-  </header>
-  <section class="clearfix">
-    <!-- THIS IS HOW A TALK ABSTRACT LOOKS LIKE
-    <div class="speaker">
-      <h3>Your topic</h3>
-      <h5><a href="http://twitter.com/your_twitter_handle">Your Name</a></h5>
-      <p>
-        Description
-      </p>
-      <p>
-        Further description
-      </p>
-    </div>
-    -->
-    <div class="three-cols clearfix">
-
-      <div class="speaker">
-        <h3>JavaScript as the future of Progressive Enhancement</h3>
-        <h5><a href="http://twitter.com/trodrigues">Tiago Rodrigues</a></h5>
-        <p>
-          In recent times the web development community has been divided over the way JavaScript is used on modern web development and how Progressive Enhancement has been abandoned by so many developers. But what if JavaScript is the future of Progressive Enhancement?
-        </p>
-        <p>
-          This talk will go through various solutions for doing modern web development while keeping JavaScript as a first class citizen and taking advantage of all the good things Progressive Enhancement has to offer.
-        </p>
-      </div>
-
-      <div class="speaker">
-        <h3>JavaScript Method Modification - Aspect Oriented Function Composition</h3>
-        <h5><a href="https://twitter.com/petsel">Peter Seliger</a></h5>
-        <p>
-          Within the last years only on GitHub the amount of JavaScript libraries that
-          claim to support Aspect Oriented Programming (AOP) has risen significantly.
-          But there is a difference between wrapping functions in a basic way and the
-          complexity that has to be handled by aspect oriented approaches.
-        </p>
-        <p>
-          The goal of this talk is to distinguish both. Live Coding examples might point
-          to what developers are really looking for.
-        </p>
-      </div>
-
-      <div class="speaker">
-        <h3>Solving the callback hell through generators and promises</h3>
-        <h5><a href="">Andreas Lubbe</a></h5>
-        <p>
-          JavaScript has the tendency to produce callback code that is constantly headed for the right edge of the screen and makes error checking &amp; handling anything but fun. The async library doesn't help much with errors, promises are slow and fibers unreliable. So what to do?
-        </p>
-        <p>
-          ES6 has introduced generators and newer libraries such as bluebird offer the flexibility of promises with the speed of async. This talk will introduce these concepts and show live demos and benchmarks.
-        </p>
-      </div>
-
-    </div>
-  </section>
-</article>
+{% for meetup in site.data.meetups %}
+  {% if meetup.time > site.time %}
+    {% include meetup.html meetup=meetup prefix="Next meetup on" %}
+  {% endif %}
+{% endfor %}

--- a/index.html
+++ b/index.html
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 ---
 layout: berlinjs
 title: Berlin's finest JavaScript Usergroup
@@ -7,3 +8,185 @@ title: Berlin's finest JavaScript Usergroup
 {% for meetup in meetups reversed | offset: last %}
   {% include meetup.html meetup=meetup prefix="Next meetup on" %}
 {% endfor %}
+=======
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>BerlinJS &mdash; Berlin's finest JavaScript Usergroup</title>
+    <meta name="description" content="Berlin.JS is a usergroup focused on JavaScript and related
+     topics. We meet regularly on the 3rd Thursday each month at 7p.m. at co.up Offices,
+     Adalbertstraße 7-8 in Berlin-Kreuzberg.">
+    <meta name="keywords" content="JavaScript, Usergroup, Berlin, Programming, JS">
+    <meta name="author" content="Berlin.JS">
+    <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1">
+    <!-- disable cache completely for now -->
+    <meta http-equiv="cache-control" content="max-age=0">
+    <meta http-equiv="cache-control" content="no-cache">
+    <meta http-equiv="expires" content="0">
+    <meta http-equiv="expires" content="Thu, 01 Jan 1970 13:37:00 GMT">
+    <meta http-equiv="pragma" content="no-cache">
+    <link rel="shortcut icon" href="favicon.ico">
+    <link rel="stylesheet" media="screen" href="css/style.css?v=1">
+    <link rel="stylesheet" media="print" href="css/print.css?v=1">
+
+    <link rel="stylesheet" media="only screen and (min-width: 480px)" href="css/480.css?v=1">
+    <link rel="stylesheet" media="only screen and (min-width: 768px)" href="css/768.css?v=1">
+    <link rel="stylesheet" media="only screen and (min-width: 992px)" href="css/992.css?v=1">
+    <link rel="stylesheet" media="only screen and (min-width: 1382px)" href="css/1382.css?v=1">
+
+    <link rel="stylesheet" media="only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2)" href="css/2x.css?v=1">
+
+    <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
+
+    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png">
+
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  </head>
+  <body>
+    <header role="banner" class="clearfix">
+      <div class="clearfix">
+        <a href="/" title="BERLIN.JS"><h1 class="logo"></h1></a>
+        <h3 class="ug-info triangle-border left">
+          Berlin.JS is a usergroup focused on JavaScript and related topics. We meet regularly on
+          the 3rd Thursday each month at 7p.m. at
+          <a href="http://co-up.de" title="co.up Coworking">co.up Offices</a>,
+          Adalbertstraße 7-8 in Berlin-Kreuzberg.
+        </h3>
+      </div>
+    </header>
+    <div role="main" class="content clearfix">
+      <article class="clearfix">
+        <header class="clearfix center">
+          <h1>Next meetup on January 16<sup>th</sup></h1>
+        </header>
+        <section class="clearfix">
+        <!-- TALKS -->
+          <!-- THIS IS HOW A TALK ABSTRACT LOOKS LIKE
+          <div class="speaker">
+            <h3>Your topic</h3>
+            <h5><a href="http://twitter.com/your_twitter_handle">Your Name</a></h5>
+            <p>
+              Description
+            </p>
+            <p>
+              Further description
+            </p>
+          </div>
+          -->
+          <div class="three-cols clearfix">
+
+            <div class="speaker">
+              <h3>Player.js: Control Media Iframes</h3>
+              <h5><a href="http://twitter.com/screeley">Sean Creeley</a></h5>
+              <p>
+                <a href="https://github.com/embedly/player.js">Player.js</a> is a library for
+                programmatically running actions like play, pause, mute, and seek for a wide variety
+                of media providers.
+              </p>
+              <p>
+                This talk will focus on building the media iframe, using postMessage and the
+                Player.js library itself. We will also discuss some of the immediate possibilities
+                like event listening for media analytics and playlist apps.
+              </p>
+            </div>
+
+            <div class="speaker">
+              <h3>Sqwiggle: How we JavaScript</h3>
+              <h5><a href="https://twitter.com/lukeroberts1990">Luke Roberts</a></h5>
+              <p>
+                Sqwiggle is an online office and collaboration space for remote
+                teams. We are on the bleeding edge with WebRTC and use a LOT of
+                JS. 
+              </p>
+              <p>
+                This talk is a brief overview of the Sqwiggle stack, WebRTC and
+                our approach to using Javascript. 
+              </p>
+            </div>
+
+            <div class="speaker empty">
+              <h3>Free slot</h3>
+              <h5>This slot could be yours!<br />Submit your talk now.</h5>
+              <p>
+                You did some crazy stuff with JavaScript? You want to show it to the community?
+              </p>
+              <p>
+                Drop us a line on your topic on <a href="http://twitter.com/berlinjs" title="BerlinJS on Twitter">
+                Twitter</a> or to our <a href="http://groups.google.com/group/js-berlin" title="BerlinJS Mailinglist">Mailinglist</a>.
+              </p>
+            </div>
+
+          </div>
+        </section>
+      </article>
+
+    </div>
+    <footer>
+      <div class="clearfix three-cols">
+        <div>
+          <h5>Get in touch</h5>
+          <ul>
+            <li>
+              Follow Berlin.JS on <a href="http://twitter.com/berlinjs" title="Follow us on Twitter">Twitter</a>
+            </li>
+            <li>
+              Join our <a href="http://groups.google.com/group/js-berlin" title="Join our Mailinglist">Mailinglist</a>
+            </li>
+            <li>
+              Watch the code on <a href="https://github.com/berlinjs/berlinjs.org" title="Berlin.JS code on Github">Github</a>
+            </li>
+            <li>
+              Browse the archive of <a href="./archive.html" title="Slides from previous meetups">Slides</a>
+            </li>
+          </ul>
+        </div>
+        <div>
+          <h5>The team</h5>
+          <p>
+            Berlin.JS is organized by <a href="http://www.twitter.com/rmehner" title="Follow Robin on
+            Twitter">Robin Mehner</a>, <a href="http://www.twitter.com/janl" title="Follow Jan on
+            Twitter">Jan Lehnardt</a> &amp; <a href="http://www.twitter.com/theophani" title="Follow Tiffany on
+            Twitter">Tiffany Conroy</a>. Design by <a href="http://www.twitter.com/m_besser"
+            title="Follow Matti on Twitter">Matti Besser</a>.
+          </p>
+        </div>
+        <div>
+          <h5>Supporters</h5>
+          <p>
+            Our Meetups are hosted by <a href="http://www.co-up.de" title="co.up Coworking">co.up</a>.
+          </p>
+        </div>
+      </div>
+      <div class="clearfix one-col">
+        <div>
+          <h5>Code of Conduct</h5>
+          <p>
+            Long story short: <strong>Be awesome to each other.</strong>
+          </p>
+
+          <p>
+            Our goal is to have an awesome and inclusive community meetup where people meet,
+            hang out together, chat, listen to talks, exchange ideas and make new friends.
+            Any harmful or discriminating behaviour will not be tolerated and results
+            in the offending person being expelled from the meetup.
+          </p>
+        </div>
+      </div>
+    </footer>
+    <script>
+      var _gaq = [['_setAccount','UA-25036346-1'],['_trackPageview']];
+      (function(d, t) {
+        var g = d.createElement(t),
+            s = d.getElementsByTagName(t)[0];
+        g.async = g.src = '//www.google-analytics.com/ga.js';
+        s.parentNode.insertBefore(g, s);
+      }(document, 'script'));
+    </script>
+  </body>
+</html>
+>>>>>>> 18b7515... Finally add code of conduct

--- a/index.html
+++ b/index.html
@@ -1,159 +1,63 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta charset="utf-8">
-    <title>BerlinJS &mdash; Berlin's finest JavaScript Usergroup</title>
-    <meta name="description" content="Berlin.JS is a usergroup focused on JavaScript and related
-     topics. We meet regularly on the 3rd Thursday each month at 7p.m. at co.up Offices,
-     Adalbertstraße 7-8 in Berlin-Kreuzberg.">
-    <meta name="keywords" content="JavaScript, Usergroup, Berlin, Programming, JS">
-    <meta name="author" content="Berlin.JS">
-    <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1">
-    <!-- disable cache completely for now -->
-    <meta http-equiv="cache-control" content="max-age=0" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="expires" content="0" />
-    <meta http-equiv="expires" content="Thu, 01 Jan 1970 13:37:00 GMT" />
-    <meta http-equiv="pragma" content="no-cache" />
-    <link rel="shortcut icon" href="favicon.ico" />
-    <link rel="stylesheet" media="screen" href="css/style.css?v=1">
-    <link rel="stylesheet" media="print" href="css/print.css?v=1">
+---
+layout: berlinjs
+title: Berlin's finest JavaScript Usergroup
+---
+<article class="clearfix">
+  <header class="clearfix center">
+    <h1>Next meetup on November 21<sup>st</sup></h1>
+  </header>
+  <section class="clearfix">
+    <!-- THIS IS HOW A TALK ABSTRACT LOOKS LIKE
+    <div class="speaker">
+      <h3>Your topic</h3>
+      <h5><a href="http://twitter.com/your_twitter_handle">Your Name</a></h5>
+      <p>
+        Description
+      </p>
+      <p>
+        Further description
+      </p>
+    </div>
+    -->
+    <div class="three-cols clearfix">
 
-    <link rel="stylesheet" media="only screen and (min-width: 480px)" href="css/480.css?v=1">
-    <link rel="stylesheet" media="only screen and (min-width: 768px)" href="css/768.css?v=1">
-    <link rel="stylesheet" media="only screen and (min-width: 992px)" href="css/992.css?v=1">
-    <link rel="stylesheet" media="only screen and (min-width: 1382px)" href="css/1382.css?v=1">
-
-    <link rel="stylesheet" media="only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2)" href="css/2x.css?v=1">
-
-    <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
-
-    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png"/>
-    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png"/>
-    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png"/>
-    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png"/>
-
-    <meta name="apple-mobile-web-app-capable" content="yes">
-    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-  </head>
-  <body>
-    <header role="banner" class="clearfix">
-      <div class="clearfix">
-        <a href="/" title="BERLIN.JS"><h1 class="logo"></h1></a>
-        <h3 class="ug-info triangle-border left">
-          Berlin.JS is a usergroup focused on JavaScript and related topics. We meet regularly on
-          the 3rd Thursday each month at 7p.m. at
-          <a href="http://co-up.de" title="co.up Coworking">co.up Offices</a>,
-          Adalbertstraße 7-8 in Berlin-Kreuzberg.
-        </h3>
+      <div class="speaker">
+        <h3>JavaScript as the future of Progressive Enhancement</h3>
+        <h5><a href="http://twitter.com/trodrigues">Tiago Rodrigues</a></h5>
+        <p>
+          In recent times the web development community has been divided over the way JavaScript is used on modern web development and how Progressive Enhancement has been abandoned by so many developers. But what if JavaScript is the future of Progressive Enhancement?
+        </p>
+        <p>
+          This talk will go through various solutions for doing modern web development while keeping JavaScript as a first class citizen and taking advantage of all the good things Progressive Enhancement has to offer.
+        </p>
       </div>
-    </header>
-    <div role="main" class="content clearfix">
-      <article class="clearfix">
-        <header class="clearfix center">
-          <h1>Next meetup on November 21<sup>st</sup></h1>
-        </header>
-        <section class="clearfix">
-        <!-- TALKS -->
-          <!-- THIS IS HOW A TALK ABSTRACT LOOKS LIKE
-          <div class="speaker">
-            <h3>Your topic</h3>
-            <h5><a href="http://twitter.com/your_twitter_handle">Your Name</a></h5>
-            <p>
-              Description
-            </p>
-            <p>
-              Further description
-            </p>
-          </div>
-          -->
-          <div class="three-cols clearfix">
 
-            <div class="speaker">
-              <h3>JavaScript as the future of Progressive Enhancement</h3>
-              <h5><a href="http://twitter.com/trodrigues">Tiago Rodrigues</a></h5>
-              <p>
-                In recent times the web development community has been divided over the way JavaScript is used on modern web development and how Progressive Enhancement has been abandoned by so many developers. But what if JavaScript is the future of Progressive Enhancement?
-              </p>
-              <p>
-                This talk will go through various solutions for doing modern web development while keeping JavaScript as a first class citizen and taking advantage of all the good things Progressive Enhancement has to offer.
-              </p>
-            </div>
+      <div class="speaker">
+        <h3>JavaScript Method Modification - Aspect Oriented Function Composition</h3>
+        <h5><a href="https://twitter.com/petsel">Peter Seliger</a></h5>
+        <p>
+          Within the last years only on GitHub the amount of JavaScript libraries that
+          claim to support Aspect Oriented Programming (AOP) has risen significantly.
+          But there is a difference between wrapping functions in a basic way and the
+          complexity that has to be handled by aspect oriented approaches.
+        </p>
+        <p>
+          The goal of this talk is to distinguish both. Live Coding examples might point
+          to what developers are really looking for.
+        </p>
+      </div>
 
-            <div class="speaker">
-              <h3>JavaScript Method Modification - Aspect Oriented Function Composition</h3>
-              <h5><a href="https://twitter.com/petsel">Peter Seliger</a></h5>
-              <p>
-                Within the last years only on GitHub the amount of JavaScript libraries that
-                claim to support Aspect Oriented Programming (AOP) has risen significantly.
-                But there is a difference between wrapping functions in a basic way and the
-                complexity that has to be handled by aspect oriented approaches.
-              </p>
-              <p>
-                The goal of this talk is to distinguish both. Live Coding examples might point
-                to what developers are really looking for.
-              </p>
-            </div>
-
-            <div class="speaker">
-              <h3>Solving the callback hell through generators and promises</h3>
-              <h5><a href="">Andreas Lubbe</a></h5>
-              <p>
-                JavaScript has the tendency to produce callback code that is constantly headed for the right edge of the screen and makes error checking &amp; handling anything but fun. The async library doesn't help much with errors, promises are slow and fibers unreliable. So what to do?
-              </p>
-              <p>
-                ES6 has introduced generators and newer libraries such as bluebird offer the flexibility of promises with the speed of async. This talk will introduce these concepts and show live demos and benchmarks.
-              </p>
-            </div>
-
-          </div>
-        </section>
-      </article>
+      <div class="speaker">
+        <h3>Solving the callback hell through generators and promises</h3>
+        <h5><a href="">Andreas Lubbe</a></h5>
+        <p>
+          JavaScript has the tendency to produce callback code that is constantly headed for the right edge of the screen and makes error checking &amp; handling anything but fun. The async library doesn't help much with errors, promises are slow and fibers unreliable. So what to do?
+        </p>
+        <p>
+          ES6 has introduced generators and newer libraries such as bluebird offer the flexibility of promises with the speed of async. This talk will introduce these concepts and show live demos and benchmarks.
+        </p>
+      </div>
 
     </div>
-    <footer class="clearfix three-cols">
-      <div>
-        <h5>Get in touch</h5>
-        <ul>
-          <li>
-            Follow Berlin.JS on <a href="http://twitter.com/berlinjs" title="Follow us on Twitter">Twitter</a>
-          </li>
-          <li>
-            Join our <a href="http://groups.google.com/group/js-berlin" title="Join our Mailinglist">Mailinglist</a>
-          </li>
-          <li>
-            Watch the code on <a href="https://github.com/berlinjs/berlinjs.org" title="Berlin.JS code on Github">Github</a>
-          </li>
-          <li>
-            Browse the archive of <a href="./archive.html" title="Slides from previous meetups">Slides</a>
-          </li>
-        </ul>
-      </div>
-      <div>
-        <h5>The team</h5>
-        <p>
-          Berlin.JS is organized by <a href="http://www.twitter.com/rmehner" title="Follow Robin on
-          Twitter">Robin Mehner</a>, <a href="http://www.twitter.com/janl" title="Follow Jan on
-          Twitter">Jan Lehnardt</a> &amp; <a href="http://www.twitter.com/theophani" title="Follow Tiffany on
-          Twitter">Tiffany Conroy</a>. Design by <a href="http://www.twitter.com/m_besser"
-          title="Follow Matti on Twitter">Matti Besser</a>.
-        </p>
-      </div>
-      <div>
-        <h5>Supporters</h5>
-        <p>
-          Our Meetups are hosted by <a href="http://www.co-up.de" title="co.up Coworking">co.up</a>.
-        </p>
-      </div>
-    </footer>
-    <script>
-      var _gaq = [['_setAccount','UA-25036346-1'],['_trackPageview']];
-      (function(d, t) {
-        var g = d.createElement(t),
-            s = d.getElementsByTagName(t)[0];
-        g.async = g.src = '//www.google-analytics.com/ga.js';
-        s.parentNode.insertBefore(g, s);
-      }(document, 'script'));
-    </script>
-  </body>
-</html>
+  </section>
+</article>


### PR DESCRIPTION
This PR
- adds configuration to compile the site with Jekyll and Markdown
- extracts a layout for BerlinJS pages
- extracts templates for meetups and empty slots
- allows for rendering talks with Markdown
