### PR TITLE
Use HTML5 style for self-enclosing tags

### DIFF
--- a/angular.html
+++ b/angular.html
@@ -21,10 +21,10 @@
 
     <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
 
-    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png"/>
-    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png"/>
-    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png"/>
-    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png"/>
+    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png">
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/apps.html
+++ b/apps.html
@@ -21,10 +21,10 @@
 
     <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
 
-    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png"/>
-    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png"/>
-    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png"/>
-    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png"/>
+    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png">
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/archive.html
+++ b/archive.html
@@ -10,12 +10,12 @@
     <meta name="author" content="Berlin.JS">
     <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1">
     <!-- disable cache completely for now -->
-    <meta http-equiv="cache-control" content="max-age=0" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="expires" content="0" />
-    <meta http-equiv="expires" content="Thu, 01 Jan 1970 13:37:00 GMT" />
-    <meta http-equiv="pragma" content="no-cache" />
-    <link rel="shortcut icon" href="favicon.ico" />
+    <meta http-equiv="cache-control" content="max-age=0">
+    <meta http-equiv="cache-control" content="no-cache">
+    <meta http-equiv="expires" content="0">
+    <meta http-equiv="expires" content="Thu, 01 Jan 1970 13:37:00 GMT">
+    <meta http-equiv="pragma" content="no-cache">
+    <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" media="screen" href="css/style.css?v=1">
     <link rel="stylesheet" media="print" href="css/print.css?v=1">
 
@@ -28,10 +28,10 @@
 
     <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
 
-    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png"/>
-    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png"/>
-    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png"/>
-    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png"/>
+    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png">
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">

--- a/index.html
+++ b/index.html
@@ -10,12 +10,12 @@
     <meta name="author" content="Berlin.JS">
     <meta name="viewport" content="width=device-width, target-densitydpi=160dpi, initial-scale=1">
     <!-- disable cache completely for now -->
-    <meta http-equiv="cache-control" content="max-age=0" />
-    <meta http-equiv="cache-control" content="no-cache" />
-    <meta http-equiv="expires" content="0" />
-    <meta http-equiv="expires" content="Thu, 01 Jan 1970 13:37:00 GMT" />
-    <meta http-equiv="pragma" content="no-cache" />
-    <link rel="shortcut icon" href="favicon.ico" />
+    <meta http-equiv="cache-control" content="max-age=0">
+    <meta http-equiv="cache-control" content="no-cache">
+    <meta http-equiv="expires" content="0">
+    <meta http-equiv="expires" content="Thu, 01 Jan 1970 13:37:00 GMT">
+    <meta http-equiv="pragma" content="no-cache">
+    <link rel="shortcut icon" href="favicon.ico">
     <link rel="stylesheet" media="screen" href="css/style.css?v=1">
     <link rel="stylesheet" media="print" href="css/print.css?v=1">
 
@@ -28,10 +28,10 @@
 
     <link href='http://fonts.googleapis.com/css?family=Droid+Sans:400,700' rel='stylesheet' type='text/css'>
 
-    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png"/>
-    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png"/>
-    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png"/>
-    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png"/>
+    <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png">
 
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
Because it used to be cutting edge some time ago. Also, it adds consistency and saves a few precious bytes.
