### PR TITLE
Remove mailing list, add link to GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,8 +135,8 @@
                 You did some great stuff with JavaScript? You want to show it to the community?
               </p>
               <p>
-                Drop us a line on your topic on <a href="http://twitter.com/berlinjs" title="BerlinJS on Twitter">
-                Twitter</a> or to our <a href="http://groups.google.com/group/js-berlin" title="BerlinJS Mailinglist">Mailinglist</a>.
+                Drop us a line on your topic on <a href="http://twitter.com/berlinjs">
+                Twitter</a> or <a href="https://github.com/berlinjs/berlinjs.org">create a pull request on GitHub</a> to this page right away.
               </p>
             </div> -->
           </div>


### PR DESCRIPTION
Hey :)

It seems like the mailing list is not used very much. So I removed the links to it on the homepage. Instead I added a link to this GitHub repo like this:

```
Drop us a line on your topic on Twitter or   
create a pull request on GitHub to this page right away.
```

I feel like it makes more sense like this.

Best,
Finn

PS: One reason for this PR is that someone contacted me because they were confused about the process.
