### PR TITLE
Add talk on GKE

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,6 +76,24 @@
             </div>
             -->
             <div class="speaker">
+              <h3>Deploying a Node.js App on Google Container Engine</h3>
+              <p class="speaker-name"><a href="https://github.com/aknuds1">Arve Knudsen</a></p>
+              <p>
+                <a href="https://cloud.google.com/container-engine/">Google Container Engine</a>
+                (GKE) is Google's service for hosting <a href="http://kubernetes.io">Kubernetes</a>
+                managed applications. Kubernetes itself being Google's open source container
+                (Docker/Rkt) management system, enabling you to create scalable clusters of
+                app containers.
+              </p>
+              <p>
+                In the <a href="https://muzhack.com">MuzHack</a> project, which uses Node.js on
+                the server, we have chosen to rely on Docker and, furthermore, deploy to Google
+                Container Engine with its Kubernetes management engine. Our experience so far
+                suggests that Kubernetes is the way forward for deploying Web services, bearing
+                in mind it is still a maturing technology.
+              </p>
+            </div>
+            <div class="speaker">
               <h3>Writing a JavaScript Compiler with Rust</h3>
               <p class="speaker-name"><a href="https://github.com/maciejhirsz">Maciej Hirsz</a></p>
               <p>


### PR DESCRIPTION
Add talk on deploying Node.js apps to Google Container Engine.
