### PR TITLE
Replace http with https

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
         <ul>
           <li>
             Follow Berlin.JS on
-            <a href="http://twitter.com/berlinjs">Twitter</a>
+            <a href="https://twitter.com/berlinjs">Twitter</a>
           </li>
           <li>
             Chat on our
@@ -143,7 +143,7 @@
           </li>
           <li>
             We're on
-            <a href="http://www.meetup.com/Berlin-JS/">Meetup</a>
+            <a href="https://www.meetup.com/Berlin-JS/">Meetup</a>
           </li>
         </ul>
       </div>
@@ -151,10 +151,10 @@
         <h2>The team</h2>
         <p>
           Berlin.JS is organized by
-          <a href="http://www.twitter.com/rmehner" title="Follow Robin on Twitter">Robin Mehner</a>,
-          <a href="http://www.twitter.com/carolstran" title="Follow Carolyn on Twitter">Carolyn Stransky</a>,
-          <a href="http://www.twitter.com/mohamed3on" title="Follow Mohamed on Twitter">Mohamed Oun</a>. Design by
-          <a href="http://www.twitter.com/m_besser" title="Follow Matti on Twitter">Matti Besser</a>.
+          <a href="https://www.twitter.com/rmehner" title="Follow Robin on Twitter">Robin Mehner</a>,
+          <a href="https://www.twitter.com/carolstran" title="Follow Carolyn on Twitter">Carolyn Stransky</a>,
+          <a href="https://www.twitter.com/mohamed3on" title="Follow Mohamed on Twitter">Mohamed Oun</a>. Design by
+          <a href="https://www.twitter.com/m_besser" title="Follow Matti on Twitter">Matti Besser</a>.
         </p>
       </div>
       <div>
@@ -180,7 +180,7 @@
           <p>
             For details on what kinds of behaviour are not tolerated and consequences for violating these rules, we
             refer to the
-            <a href="http://rubyberlin.github.io/code-of-conduct">Berlin Code of Conduct</a>.
+            <a href="https://rubyberlin.github.io/code-of-conduct">Berlin Code of Conduct</a>.
           </p>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -28,12 +28,12 @@
   <link rel="stylesheet" media="only screen and (-webkit-min-device-pixel-ratio: 2), only screen and (min-device-pixel-ratio: 2)"
     href="css/2x.css?v=1">
 
-  <link href="http://fonts.googleapis.com/css?family=Droid+Sans:400,700" rel="stylesheet" type="text/css">
+  <link href="https://fonts.googleapis.com/css?family=Droid+Sans:400,700" rel="stylesheet" type="text/css">
 
-  <link rel="apple-touch-icon-precomposed" href="http://berlinjs.org/apple-touch-icon-precomposed.png">
-  <link rel="apple-touch-icon" sizes="72x72" href="http://berlinjs.org/apple-touch-icon-72x72.png">
-  <link rel="apple-touch-icon" sizes="114x114" href="http://berlinjs.org/apple-touch-icon-114x114.png">
-  <link rel="apple-touch-icon" sizes="144x144" href="http://berlinjs.org/apple-touch-icon-144x144.png">
+  <link rel="apple-touch-icon-precomposed" href="https://berlinjs.org/apple-touch-icon-precomposed.png">
+  <link rel="apple-touch-icon" sizes="72x72" href="https://berlinjs.org/apple-touch-icon-72x72.png">
+  <link rel="apple-touch-icon" sizes="114x114" href="https://berlinjs.org/apple-touch-icon-114x114.png">
+  <link rel="apple-touch-icon" sizes="144x144" href="https://berlinjs.org/apple-touch-icon-144x144.png">
 
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">


### PR DESCRIPTION
Hi, while I was checking out tonight's lineup I saw a mixed content warning in Chrome.

> Mixed Content: The page at 'https://berlinjs.org/' was loaded over HTTPS, but requested an insecure stylesheet 'http://fonts.googleapis.com/css?family=Droid+Sans:400,700'. This request has been blocked; the content must be served over HTTPS.

This is why I went ahead and created this pull request. It updates all <link/> tags to use HTTPS. I double checked that all links are accessible via HTTPS.

I also updated most of the outgoing links to use HTTPS when possible. Only http://co-up.de/ can't be reached over an HTTPS connection which is why I left those links untouched.

Please let me know if I need to change anything. See you tonight. :-)